### PR TITLE
set different default itzo version based on runtime.GOARCH

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         prerelease: false
     - name: Upload amd64 release asset
       if: startsWith(github.event.ref, 'refs/tags/v')
-      id: upload-release-asset 
+      id: upload-release-amd64-asset
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
         asset_content_type: application/octet-stream
     - name: Upload arm64 release asset
       if: startsWith(github.event.ref, 'refs/tags/v')
-      id: upload-release-asset
+      id: upload-release-arm64-asset
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         release_name: Release ${{ github.ref }}
         draft: false
         prerelease: false
-    - name: Upload release asset
+    - name: Upload amd64 release asset
       if: startsWith(github.event.ref, 'refs/tags/v')
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1
@@ -42,4 +42,15 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./itzo-launcher
         asset_name: itzo-launcher-amd64
+        asset_content_type: application/octet-stream
+    - name: Upload arm64 release asset
+      if: startsWith(github.event.ref, 'refs/tags/v')
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./itzo-launcher-arm64
+        asset_name: itzo-launcher-arm64
         asset_content_type: application/octet-stream

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CURRENT_TIME=$(shell date +%Y%m%d%H%M%S)
 LD_VERSION_FLAGS=-X main.BuildVersion=$(GIT_VERSION) -X main.BuildTime=$(CURRENT_TIME)
 LDFLAGS=-ldflags "$(LD_VERSION_FLAGS)"
 
-BINARIES=itzo-launcher
+BINARIES=itzo-launcher itzo-launcher-arm64
 
 TOP_DIR=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 CMD_SRC=$(shell find $(TOP_DIR)cmd -type f -name '*.go')
@@ -16,6 +16,9 @@ all: $(BINARIES)
 
 itzo-launcher: $(CMD_SRC) $(PKG_SRC) go.sum
 	go build $(LDFLAGS) -o itzo-launcher cmd/itzo-launcher/itzo-launcher.go
+
+itzo-launcher-arm64: $(CMD_SRC) $(PKG_SRC) go.sum
+	GOARCH=arm64 GOOS=linux go build $(LDFLAGS) -o itzo-launcher-arm64 cmd/itzo-launcher/itzo-launcher.go
 
 clean:
 	rm -f $(BINARIES)

--- a/cmd/itzo-launcher/itzo-launcher.go
+++ b/cmd/itzo-launcher/itzo-launcher.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -23,8 +24,6 @@ import (
 const (
 	ItzoDir                   = "/tmp/itzo"
 	ItzoDefaultPath           = "/usr/local/bin/itzo"
-	ItzoDefaultURL            = "https://itzo-kip-download.s3.amazonaws.com"
-	ItzoDefaultVersion        = "latest"
 	ItzoURLFile               = ItzoDir + "/itzo_url"
 	ItzoVersionFile           = ItzoDir + "/itzo_version"
 	CellConfigFile            = ItzoDir + "/cell_config.yaml"
@@ -39,7 +38,20 @@ var (
 var (
 	version    = flag.Bool("version", false, "print version and exit")
 	itzoLogDir = flag.String("itzo-log-dir", "/var/log/itzo", "directory for itzo.log")
+	ItzoDefaultURL = "https://itzo-kip-download.s3.amazonaws.com"
+	ItzoDefaultVersion = "latest"
 )
+
+func init()  {
+	switch runtime.GOARCH {
+	case "arm64":
+		ItzoDefaultURL = "https://itzo-kip-download.s3.amazonaws.com"
+		ItzoDefaultVersion = "arm-latest"
+	default:
+		ItzoDefaultURL = "https://itzo-kip-download.s3.amazonaws.com"
+		ItzoDefaultVersion = "latest"
+	}
+}
 
 func ProcessInstanceParameters() error {
 	klog.V(2).Infof("checking instance parameters")

--- a/cmd/itzo-launcher/itzo-launcher.go
+++ b/cmd/itzo-launcher/itzo-launcher.go
@@ -28,6 +28,9 @@ const (
 	ItzoVersionFile           = ItzoDir + "/itzo_version"
 	CellConfigFile            = ItzoDir + "/cell_config.yaml"
 	InstanceParameterBasePath = "/kip/cells"
+	ItzoDefaultURL            = "https://itzo-kip-download.s3.amazonaws.com"
+	ItzoDefaultVersionAMD64   = "latest"
+	ItzoDefaultVersionARM64   = "arm-latest"
 )
 
 var (
@@ -38,19 +41,51 @@ var (
 var (
 	version    = flag.Bool("version", false, "print version and exit")
 	itzoLogDir = flag.String("itzo-log-dir", "/var/log/itzo", "directory for itzo.log")
-	ItzoDefaultURL = "https://itzo-kip-download.s3.amazonaws.com"
-	ItzoDefaultVersion = "latest"
 )
 
-func init()  {
+func getItzoURL() (string, error) {
+	itzoURL := ItzoDefaultURL
+	contents, err := ioutil.ReadFile(ItzoURLFile)
+	if err != nil && os.IsNotExist(err) {
+		klog.Warningf("reading %s: %v; using defaults", ItzoURLFile, err)
+	} else if err != nil {
+		err = fmt.Errorf("reading %s: %v", ItzoURLFile, err)
+		klog.Errorf("%v", err)
+		return "", err
+	} else {
+		itzoURL = strings.TrimSpace(string(contents))
+	}
+	return itzoURL, nil
+}
+
+func getItzoDefaultVersion() string {
 	switch runtime.GOARCH {
 	case "arm64":
-		ItzoDefaultURL = "https://itzo-kip-download.s3.amazonaws.com"
-		ItzoDefaultVersion = "arm-latest"
+		return ItzoDefaultVersionARM64
 	default:
-		ItzoDefaultURL = "https://itzo-kip-download.s3.amazonaws.com"
-		ItzoDefaultVersion = "latest"
+		return ItzoDefaultVersionAMD64
 	}
+}
+
+func getItzoVersion() (string, error) {
+	itzoVersion := getItzoDefaultVersion()
+	contents, err := ioutil.ReadFile(ItzoVersionFile)
+	if err != nil && os.IsNotExist(err) {
+		klog.Warningf("reading %s: %v; using defaults", ItzoVersionFile, err)
+	} else if err != nil {
+		err = fmt.Errorf("reading %s: %v", ItzoVersionFile, err)
+		klog.Errorf("%v", err)
+		return "", err
+	} else {
+		itzoVersion = strings.TrimSpace(string(contents))
+	}
+	if itzoVersion == "" {
+		// Set it to 0.0.0, so if itzo is already installed, it will be used,
+		// whatever version it is.
+		itzoVersion = "0.0.0"
+		klog.Warningf("empty itzo version, using %q", itzoVersion)
+	}
+	return itzoVersion, nil
 }
 
 func ProcessInstanceParameters() error {
@@ -92,37 +127,17 @@ func ProcessUserData() error {
 
 func EnsureItzo() (string, error) {
 	klog.V(2).Infof("downloading itzo")
-	itzoURL := ItzoDefaultURL
-	contents, err := ioutil.ReadFile(ItzoURLFile)
-	if err != nil && os.IsNotExist(err) {
-		klog.Warningf("reading %s: %v; using defaults", ItzoURLFile, err)
-	} else if err != nil {
-		err = fmt.Errorf("reading %s: %v", ItzoURLFile, err)
-		klog.Errorf("%v", err)
+	itzoURL, err := getItzoURL()
+	if err != nil {
 		return "", err
-	} else {
-		itzoURL = strings.TrimSpace(string(contents))
 	}
-	itzoVersion := ItzoDefaultVersion
-	contents, err = ioutil.ReadFile(ItzoVersionFile)
-	if err != nil && os.IsNotExist(err) {
-		klog.Warningf("reading %s: %v; using defaults", ItzoVersionFile, err)
-	} else if err != nil {
-		err = fmt.Errorf("reading %s: %v", ItzoVersionFile, err)
-		klog.Errorf("%v", err)
+	itzoVersion, err := getItzoVersion()
+	if err != nil {
 		return "", err
-	} else {
-		itzoVersion = strings.TrimSpace(string(contents))
-	}
-	if itzoVersion == "" {
-		// Set it to 0.0.0, so if itzo is already installed, it will be used,
-		// whatever version it is.
-		itzoVersion = "0.0.0"
-		klog.Warningf("empty itzo version, using %q", itzoVersion)
 	}
 	itzoDownloadURL := fmt.Sprintf("%s/itzo-%s", itzoURL, itzoVersion)
 	itzoPath := ItzoDefaultPath
-	if itzoVersion != ItzoDefaultVersion {
+	if itzoVersion != getItzoDefaultVersion() {
 		itzoPath, err = util.EnsureProg(ItzoDefaultPath, itzoDownloadURL, itzoVersion, "--version")
 		if err != nil {
 			klog.Errorf("ensuring itzo version %q: %v", itzoVersion, err)


### PR DESCRIPTION
We need this, because in multi-arch nodeless cluster, KIP has to rely on default versions downloaded by itzo-launcher. We merged this [PR](https://github.com/elotl/itzo/pull/137) and now each itzo release uploads binaries to  `https://itzo-kip-download.s3.amazonaws.com` with following pattern:
- `itzo-latest` (amd64)
- `itzo-latest-arm64` (arm64)
- `itzo-latest-darwin` (darwin, we may want to remove those from itzo release pipeline)